### PR TITLE
予約表をスマホ向けに対応

### DIFF
--- a/src/components/ReservationTable.vue
+++ b/src/components/ReservationTable.vue
@@ -91,26 +91,23 @@ const handleDelete = (id) => {
 </template>
 
 <style>
-body {
-  margin-bottom: 40px;
-}
-table {
-  border-collapse: collapse;
-}
-
-
 /* スマホ向けのスタイル */
 @media (max-width: 768px) {
+  body {
+    margin-bottom: 40px;
+  }
   table {
     border-collapse: collapse;
-    width: 350px;
+  }
+  th {
+    writing-mode: vertical-rl; /* 縦書きに設定 */
   }
   .name-space {
-    font-size: 10px;
+    font-size: 12px;
     white-space: nowrap; /* 自動改行を防ぐ */
   }
   .number-space {
-    font-size: 10px;
+    font-size: 12px;
   }
   .time-space {
     font-size: 10px; /* 卓番号が見えるように文字の大きさを調整 */
@@ -119,5 +116,4 @@ table {
     font-size: 10px;
   }
 }
-
 </style>

--- a/src/components/ReservationTable.vue
+++ b/src/components/ReservationTable.vue
@@ -103,7 +103,7 @@ table {
 @media (max-width: 768px) {
   table {
     border-collapse: collapse;
-    width: 270px;
+    width: 350px;
   }
   .name-space {
     font-size: 10px;

--- a/src/components/ReservationTable.vue
+++ b/src/components/ReservationTable.vue
@@ -98,20 +98,25 @@ table {
   border-collapse: collapse;
 }
 
+
 /* スマホ向けのスタイル */
 @media (max-width: 768px) {
+  table {
+    border-collapse: collapse;
+    width: 270px;
+  }
   .name-space {
-    padding: 12px;
+    font-size: 10px;
     white-space: nowrap; /* 自動改行を防ぐ */
   }
   .number-space {
-    padding: 12px;
+    font-size: 10px;
   }
   .time-space {
-    padding: 12px;
+    font-size: 10px; /* 卓番号が見えるように文字の大きさを調整 */
   }
   .table-space {
-    padding: 12px;
+    font-size: 10px;
   }
 }
 

--- a/src/components/ReservationTable.vue
+++ b/src/components/ReservationTable.vue
@@ -91,22 +91,28 @@ const handleDelete = (id) => {
 </template>
 
 <style>
-table {
-  border-collapse: collapse;
-}
-.name-space {
-  padding-left: 48px;
-}
-.number-space {
-  padding-left: 24px;
-}
-.time-space {
-  padding-left: 40px;
-}
-.table-space {
-  padding-left: 16px;
-}
 body {
   margin-bottom: 40px;
 }
+table {
+  border-collapse: collapse;
+}
+
+/* スマホ向けのスタイル */
+@media (max-width: 768px) {
+  .name-space {
+    padding: 12px;
+    white-space: nowrap; /* 自動改行を防ぐ */
+  }
+  .number-space {
+    padding: 12px;
+  }
+  .time-space {
+    padding: 12px;
+  }
+  .table-space {
+    padding: 12px;
+  }
+}
+
 </style>


### PR DESCRIPTION
ウェブ上で、スマホでの表示を確認したい場合
デベロッパーツールを開き、デベロッパーツールの左上のデバイスアイコンをクリックする。画面上部のプルダウンメニューで iPhone 12 や Pixel 7 などを選択。この手順により、ウェブ上でスマホの画面のように見ることができる。