### PR TITLE
ログインやサインアップ時のアラートの追加

### DIFF
--- a/pages/Signup.vue
+++ b/pages/Signup.vue
@@ -13,6 +13,26 @@ const { signup } = useAuth()
 const router = useRouter()
 
 const handleSignup = async () => {
+  if (!email.value) {
+    alert('メールアドレスが入力されていません')
+    return
+  }
+
+  if (!username.value) {
+    alert('ユーザーネームが入力されていません')
+    return
+  }
+
+  if (!password.value) {
+    alert('パスワードが入力されていません')
+    return
+  }
+
+  if (!confirmPassword.value) {
+    alert('パスワード(確認用)が入力されていません')
+    return
+  }
+
   if (!isValidBirthdayFormat(password.value)) {
     alert('パスワードの形式が正しくありません')
     return
@@ -25,13 +45,13 @@ const handleSignup = async () => {
 
   try {
     await signup(email.value, password.value, username.value)
-    alert('アカウント作成成功！')
+    alert('アカウント作成に成功しました')
     router.push('/')
   } catch (e) {
     if (e.code === 'auth/email-already-in-use') {
       alert('このメールアドレスはすでに使用されています')
     } else {
-      alert('アカウント作成失敗: ' + e.message)
+      alert('アカウント作成に失敗しました')
     }
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -11,6 +11,16 @@ const { login } = useAuth()
 const router = useRouter()
 
 const handleLogin = async () => {
+  if (!email.value) {
+    alert('メールアドレスが入力されていません')
+    return
+  }
+
+  if (!password.value) {
+    alert('パスワードが入力されていません')
+    return
+  }
+
   if (!isValidBirthdayFormat(password.value)) {
     alert('パスワードの形式が正しくありません')
     return
@@ -18,10 +28,14 @@ const handleLogin = async () => {
 
   try {
     await login(email.value, password.value)
-    alert('ログイン成功！')
+    alert('ログインに成功しました')
     router.push('/HomePage')
   } catch (e) {
-    alert('ログイン失敗: ' + e.message)
+    if (e.code === 'auth/invalid-credential') {
+      alert('メールアドレスまたはパスワードが間違っています')
+    } else {
+      alert('ログインに失敗しました')
+    }
   }
 }
 </script>


### PR DESCRIPTION
**ログイン時**
・メールアドレスの入力がされていないときのアラート
・パスワードが入力されていないときのアラート
・パスワードの形式が正しくなかったときのアラート
・ログインに成功したときのアラート（今後必要かどうか定義するが、とりあえずこのまま）
・メアドかパスワードが間違っているときのアラート
・ログインに失敗したときのアラート（サーバー関係のエラーを表すため必要）

**サインアップ時**
・メアド、ユーザーネーム、パスワード、パスワード（確認用）のそれぞれが、入力されていないときのアラート
・パスワードの形式が正しくないときのアラート
・パスワードとパスワード（確認用）があっていないときのアラート
・アカウント作成に成功したときのアラート（今後必要かどうか定義するが、とりあえずこのまま）
・メールアドレスが既に使用されているときのアラート
・アカウント作成に失敗したときのアラート（サーバー関係のエラーを表すため必要）

上記の内容を満たしているかの確認と、冗長なアラートや、追加のアラートの提案があったら教えてほしいです。