### PR TITLE
予約表での「人数」の幅調整

### DIFF
--- a/pages/ReservationTableCompact.vue
+++ b/pages/ReservationTableCompact.vue
@@ -155,7 +155,7 @@ table th.name {
 }
 
 table th.people {
-  width: 9%;
+  width: 14%;
   writing-mode: horizontal-tb;
 }
 
@@ -170,7 +170,7 @@ table th.seat {
 }
 
 table th.info {
-  width: 45%;
+  width: 40%;
   writing-mode: horizontal-tb;
 }
 


### PR DESCRIPTION
ReservationTableCompact.vueでの予約表の「人数」欄の幅調整をして、「人数」という文字が縦書きにならないように調整。