### PR TITLE
EditShiftページでの文字の色の修正

### DIFF
--- a/pages/EditShift.vue
+++ b/pages/EditShift.vue
@@ -184,6 +184,7 @@ input[type="text"] {
   margin: 0 auto;
   margin-top: 16px;
   font-size: 16px;
+  color: black;
   background-color: #e0e0e0;
   border: 2px dashed #333;
   border-radius: 6px;


### PR DESCRIPTION
スマホでのEditShiftページで、＋行を追加ボタンの文字色が黒になるように調整を行いました。