### PR TITLE
フォーム入力時に画面が大きくならないように調整

### DIFF
--- a/pages/EditForm.vue
+++ b/pages/EditForm.vue
@@ -104,6 +104,7 @@ function initFlatpicker() {
     dateFormat: "Y-m-d H:i",
     locale: Japanese,
     defaultDate: formData.time,
+    disableMobile: true,
   })
 }
 
@@ -253,13 +254,14 @@ h1 {
 }
 
 .form-group input,
-.form-group textarea .submit-button,
-select{
+.form-group textarea,
+select {
   width: 100%;
   padding: 10px;
   border: 2px solid rgb(187, 182, 182);
   border-radius: 4px;
   box-sizing: border-box;
+  font-size: 16px;
 }
 
 .form-group textarea {

--- a/pages/ReservationForm.vue
+++ b/pages/ReservationForm.vue
@@ -65,6 +65,7 @@ onMounted(() => {
     dateFormat: 'Y-m-d H:i',
     locale: Japanese,
     defaultDate: formData.time || null,
+    disableMobile: true,
     onChange: function (_, dateStr) {
       formData.time = dateStr
     }
@@ -211,6 +212,7 @@ select {
   border: 2px solid rgb(187, 182, 182);
   border-radius: 4px;
   box-sizing: border-box;
+  font-size: 16px;
 }
 
 .form-group textarea {

--- a/pages/Shift.vue
+++ b/pages/Shift.vue
@@ -115,6 +115,7 @@ input {
   border-radius: 5px;
   border: 1px solid #ddd;
   flex: 1;
+  font-size: 16px;
 }
 
 button {


### PR DESCRIPTION
・EditFormページやReservationFormページ、Shiftページで、スマホでの入力時に画面が大きくならないように調整を行いました。

フォントサイズが15px以下だとスマホで自動拡大が起こるようなので、以下のリンクを参考にし、フォントサイズの変更などを行いました。

https://cly7796.net/blog/css/the-screen-zooms-when-filling-out-forms-on-ios/