### PR TITLE
新規受付の時間欄の復元

### DIFF
--- a/pages/ReservationForm.vue
+++ b/pages/ReservationForm.vue
@@ -68,7 +68,7 @@ onMounted(() => {
     dateFormat: 'Y-m-d H:i',
     locale: Japanese,
     defaultDate: formData.time || null,
-    disableMobile: true,
+    //disableMobile: true,
     onChange: function (_, dateStr) {
       formData.time = dateStr
     }


### PR DESCRIPTION
一旦、新規受付の時間入力がやりづらかったため、過去の時間入力方法に戻しました。