### PR TITLE
カレンダーの微調整 & 時間ピッカーの作成

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "nuxt build",
-    "dev": "nuxt dev",
+    "dev": "nuxt dev --host 0.0.0.0",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare"

--- a/pages/ReservationForm.vue
+++ b/pages/ReservationForm.vue
@@ -411,7 +411,7 @@ onBeforeUnmount(() => {
 .header-title {
   flex: 1;
   text-align: center;
-  font-size: 16px;
+  font-size: 20px;
 }
 
 .weekdays, .days {

--- a/pages/ReservationForm.vue
+++ b/pages/ReservationForm.vue
@@ -190,7 +190,7 @@ onBeforeUnmount(() => {
         <div v-if="showCalendar" class="calendar" ref="calendarRef">
           <div class="header">
             <button type="button" @click="prevMonth">‹</button>
-            {{ year }}年{{ month + 1 }}月
+            <div class="header-title">{{ year }}年{{ month + 1 }}月</div>
             <button type="button" @click="nextMonth">›</button>
           </div>
           <div class="weekdays">
@@ -318,18 +318,39 @@ onBeforeUnmount(() => {
 .calendar {
   width: 100%;
   border: 1px solid #ccc;
-  padding: 1rem;
+  padding: 1rem 1rem 0.5rem;;
   background: white;
   position: absolute;
   box-sizing: border-box;
   font-size: 16px;
   z-index: 1000;
+  border-radius: 3%;
 }
 
 .header {
   display: flex;
+  align-items: center;
   justify-content: space-between;
   margin-bottom: 0.5rem;
+}
+
+.header button {
+  display: flex;
+  background: none;
+  border: none;
+  color: blue;
+  font-size: 30px;
+  width: 40px;
+  height: 40px;
+  align-items: center;
+  justify-content: center;
+  padding: 0 10px;
+}
+
+.header-title {
+  flex: 1;
+  text-align: center;
+  font-size: 16px;
 }
 
 .weekdays, .days {
@@ -338,32 +359,54 @@ onBeforeUnmount(() => {
   text-align: center;
 }
 
+.weekdays span {
+  color: rgb(164, 164, 164);
+}
+
 .days span {
   cursor: pointer;
   padding: 0.65rem;
 }
 
 .days span.today {
+  color: blue;
+  font-weight: bold;
+}
+
+.days span.today:not(.selected) {
   color: #007bff;
   font-weight: bold;
 }
 
 .days span.selected {
-  color: #007bff;
+  color: blue;
   background-color: #cce5ff;
   border-radius: 50%;
   font-weight: bold;
 }
 
+.days span.today.selected {
+  color: white;
+  background-color: blue;
+}
+
 .calender-buttons {
   display: flex;
   justify-content: space-between;
-  margin-top: 16px;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid #ccc;
+  margin-left: -1rem;
+  margin-right: -1rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  width: calc(100% + 2rem);
+  box-sizing: border-box;
 }
 
 .calender-buttons button {
   background: transparent;
-  color: #007bff;
+  color: blue;
   font-size: 16px;
   padding: 8px 16px;
   border: none;

--- a/pages/ReservationForm.vue
+++ b/pages/ReservationForm.vue
@@ -123,12 +123,19 @@ const goBackWithDate = () => {
 }
 
 const calendarRef = ref(null)
+const timePickerRef = ref(null)
 
 function handleClickOutside(event) {
   const calendar = calendarRef.value
   const dateInput = event.target.closest('input[readonly]')
   if (calendar && !calendar.contains(event.target) && !dateInput) {
     showCalendar.value = false
+  }
+
+  const timePicker = timePickerRef.value
+  const timeInput = event.target.closest('#time')
+  if (timePicker && !timePicker.contains(event.target) && !timeInput) {
+    showTimePicker.value = false
   }
 }
 
@@ -268,8 +275,7 @@ onBeforeUnmount(() => {
           readonly
           @click="openCustomTimePicker"
         />
-
-        <div v-if="showTimePicker" class="time-picker">
+        <div v-if="showTimePicker" class="time-picker" ref="timePickerRef">
           <div class="time-highlight"></div>
           <div class="time-columns">
             <div class="time-column">

--- a/pages/ReservationForm.vue
+++ b/pages/ReservationForm.vue
@@ -325,6 +325,11 @@ onBeforeUnmount(() => {
   font-size: 16px;
   z-index: 1000;
   border-radius: 15px;
+  /*font-family: sans-serif;*/
+  /*font-family:"HGPｺﾞｼｯｸE"; /* だいぶこれが近いかも */
+  /*font-family:"HGSｺﾞｼｯｸE"; /* これもだいぶ近い */
+  /*font-family: "メイリオ";*/
+  font-family: "Noto Sans JP";
 }
 
 .header {
@@ -357,6 +362,7 @@ onBeforeUnmount(() => {
   display: grid;
   grid-template-columns: repeat(7, 1fr);
   text-align: center;
+  /*font-family: "Zen Maru Gothic", serif;*/
 }
 
 .weekdays span {

--- a/pages/ReservationForm.vue
+++ b/pages/ReservationForm.vue
@@ -114,14 +114,6 @@ const submitReservation = () => {
   }
 }
 
-const openTimePicker = (event) => {
-  event.target.focus()
-
-  if (event.target.showPicker) {
-    event.target.showPicker()
-  }
-}
-
 const goBackWithDate = () => {
   if (formData.date) {
     router.push(`/ReservationTableCompact?date=${formData.date}`)
@@ -138,6 +130,37 @@ function handleClickOutside(event) {
   if (calendar && !calendar.contains(event.target) && !dateInput) {
     showCalendar.value = false
   }
+}
+
+const showTimePicker = ref(false)
+const selectedHour = ref('')
+const selectedMinute = ref('')
+
+const hours = Array.from({ length: 24 }, (_, i) => String(i).padStart(2, '0'))
+const minutes = Array.from({ length: 12 }, (_, i) => String(i * 5).padStart(2, '0'))
+
+function openCustomTimePicker() {
+  showTimePicker.value = true
+  if (formData.time) {
+    const [h, m] = formData.time.split(':')
+    selectedHour.value = h
+    selectedMinute.value = m
+  } else {
+    selectedHour.value = '00'
+    selectedMinute.value = '00'
+  }
+}
+
+function applySelectedTime() {
+  formData.time = `${selectedHour.value}:${selectedMinute.value}`
+  showTimePicker.value = false
+}
+
+function resetTime() {
+  formData.time = ''
+  selectedHour.value = '00'
+  selectedMinute.value = '00'
+  showTimePicker.value = false
 }
 
 onMounted(() => {
@@ -238,7 +261,44 @@ onBeforeUnmount(() => {
           <span class="label-text">時間</span>
           <span class="required-mark">＊</span>
         </label>
-        <input type="time"  id="time" v-model="formData.time" required @click="openTimePicker" />
+        <input
+          type="text"
+          id="time"
+          :value="formData.time"
+          readonly
+          @click="openCustomTimePicker"
+        />
+
+        <div v-if="showTimePicker" class="time-picker">
+          <div class="time-highlight"></div>
+          <div class="time-columns">
+            <div class="time-column">
+              <div
+                v-for="h in hours"
+                :key="h"
+                :class="{ selected: h === selectedHour }"
+                @click="selectedHour = h"
+              >
+                {{ h }}
+              </div>
+            </div>
+            <span class="colon">:</span>
+            <div class="time-column">
+              <div
+                v-for="m in minutes"
+                :key="m"
+                :class="{ selected: m === selectedMinute }"
+                @click="selectedMinute = m"
+              >
+                {{ m }}
+              </div>
+            </div>
+          </div>
+          <div class="time-buttons">
+            <button type="button" @click="resetTime">リセット</button>
+            <button type="button" @click="applySelectedTime">完了</button>
+          </div>
+        </div>
       </div>
 
       <div class="form-group row">
@@ -322,13 +382,9 @@ onBeforeUnmount(() => {
   background: white;
   position: absolute;
   box-sizing: border-box;
-  font-size: 16px;
+  font-size: 20px;
   z-index: 1000;
   border-radius: 15px;
-  /*font-family: sans-serif;*/
-  /*font-family:"HGPｺﾞｼｯｸE"; /* だいぶこれが近いかも */
-  /*font-family:"HGSｺﾞｼｯｸE"; /* これもだいぶ近い */
-  /*font-family: "メイリオ";*/
   font-family: "Noto Sans JP";
 }
 
@@ -362,7 +418,6 @@ onBeforeUnmount(() => {
   display: grid;
   grid-template-columns: repeat(7, 1fr);
   text-align: center;
-  /*font-family: "Zen Maru Gothic", serif;*/
 }
 
 .weekdays span {
@@ -417,6 +472,72 @@ onBeforeUnmount(() => {
   padding: 8px 16px;
   border: none;
   border-radius: 4px;
+  cursor: pointer;
+}
+
+.time-picker {
+  width: 100%;
+  border: 1px solid #ccc;
+  padding: 1rem;
+  background: white;
+  position: absolute;
+  box-sizing: border-box;
+  font-size: 16px;
+  z-index: 1000;
+  border-radius: 15px;
+}
+
+.time-columns {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.time-column {
+  height: 120px;
+  overflow-y: scroll;
+  scroll-snap-type: y mandatory;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.time-column::-webkit-scrollbar {
+  display: none;
+}
+
+.time-column div {
+  padding: 8px;
+  cursor: pointer;
+  text-align: center;
+  font-size: 20px;
+}
+
+.time-column div.selected {
+  background-color: #cce5ff;
+  font-weight: bold;
+  border-radius: 4px;
+}
+
+.colon {
+  font-size: 20px;
+  font-weight: bold;
+  padding: 0 10px;
+}
+
+.time-buttons {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 30px;
+  border-top: 1px solid #ccc;
+  padding-top: 8px;
+}
+
+.time-buttons button {
+  background: transparent;
+  color: blue;
+  font-size: 16px;
+  padding: 8px 16px;
+  border: none;
   cursor: pointer;
 }
 

--- a/pages/ReservationForm.vue
+++ b/pages/ReservationForm.vue
@@ -324,7 +324,7 @@ onBeforeUnmount(() => {
   box-sizing: border-box;
   font-size: 16px;
   z-index: 1000;
-  border-radius: 3%;
+  border-radius: 15px;
 }
 
 .header {
@@ -458,7 +458,6 @@ select {
   resize: none;
 }
 
-input[type="date"],
 input[type="time"] {
   appearance: none;
   -webkit-appearance: none;

--- a/pages/ReservationForm.vue
+++ b/pages/ReservationForm.vue
@@ -392,8 +392,6 @@ onBeforeUnmount(() => {
   box-sizing: border-box;
   z-index: 1000;
   border-radius: 15px;
-  /*font-family: "Noto Sans JP";*/
-  /*font-family: sans-serif;*/
   font-family: Arial;
 }
 
@@ -443,13 +441,10 @@ onBeforeUnmount(() => {
 }
 
 .days span {
-  /*cursor: pointer;
-  padding: 0.65rem;*/
   display: flex;
   align-items: center;
   justify-content: center;
   height: 45px;
-  /* 固定高さを設定 */
   box-sizing: border-box;
   font-size: 20px;
 }
@@ -532,6 +527,7 @@ onBeforeUnmount(() => {
   scroll-snap-type: y mandatory;
   scrollbar-width: none;
   -ms-overflow-style: none;
+  font-family: Arial;
 }
 
 .time-column::-webkit-scrollbar {

--- a/pages/ReservationForm.vue
+++ b/pages/ReservationForm.vue
@@ -161,9 +161,19 @@ function openCustomTimePicker() {
     selectedHour.value = h
     selectedMinute.value = m
   } else {
-    selectedHour.value = '00'
+    selectedHour.value = '17'
     selectedMinute.value = '00'
   }
+}
+
+function selectHour(h) {
+  selectedHour.value = h
+  formData.time = `${h}:${selectedMinute.value}`
+}
+
+function selectMinute(m) {
+  selectedMinute.value = m
+  formData.time = `${selectedHour.value}:${m}`
 }
 
 function applySelectedTime() {
@@ -232,28 +242,19 @@ onBeforeUnmount(() => {
             <button type="button" @click="nextMonth">›</button>
           </div>
           <div class="weekdays">
-            <span
-              v-for="(w, i) in weekdays"
-              :key="w"
-              :class="{
+            <span v-for="(w, i) in weekdays" :key="w" :class="{
                 sunday: i === 0,
                 saturday: i === 6
-              }"
-            >
+              }">
               {{ w }}
             </span>
           </div>
           <div class="days">
             <span v-for="n in firstDay" :key="'blank' + n"></span>
-            <span
-              v-for="d in daysInMonth"
-              :key="d"
-              @click="selectDate(d)"
-              :class="[
+            <span v-for="d in daysInMonth" :key="d" @click="selectDate(d)" :class="[
                 { today: isToday(d), selected: isSelected(d) },
                 getDayClass(d)
-              ]"
-            >
+              ]">
               {{ d }}
             </span>
           </div>
@@ -290,14 +291,13 @@ onBeforeUnmount(() => {
           <div class="time-highlight"></div>
           <div class="time-columns">
             <div class="time-column">
-              <div v-for="h in hours" :key="h" :class="{ selected: h === selectedHour }" @click="selectedHour = h">
+              <div v-for="h in hours" :key="h" :class="{ selected: h === selectedHour }" @click="() => selectHour(h)">
                 {{ h }}
               </div>
             </div>
             <span class="colon">:</span>
             <div class="time-column">
-              <div v-for="m in minutes" :key="m" :class="{ selected: m === selectedMinute }"
-                @click="selectedMinute = m">
+              <div v-for="m in minutes" :key="m" :class="{ selected: m === selectedMinute }" @click="() => selectMinute(m)">
                 {{ m }}
               </div>
             </div>
@@ -390,7 +390,6 @@ onBeforeUnmount(() => {
   background: white;
   position: absolute;
   box-sizing: border-box;
-  font-size: 20px;
   z-index: 1000;
   border-radius: 15px;
   /*font-family: "Noto Sans JP";*/
@@ -432,6 +431,7 @@ onBeforeUnmount(() => {
 
 .weekdays span {
   color: rgb(164, 164, 164);
+  font-size: 14px;
 }
 
 .weekdays .sunday {
@@ -451,6 +451,7 @@ onBeforeUnmount(() => {
   height: 45px;
   /* 固定高さを設定 */
   box-sizing: border-box;
+  font-size: 20px;
 }
 
 .days span.today {
@@ -460,7 +461,7 @@ onBeforeUnmount(() => {
 
 .days span.today:not(.selected) {
   color: rgb(0, 130, 255);
-  font-weight: bold;
+  font-weight: normal;
 }
 
 .days span.selected {
@@ -539,7 +540,6 @@ onBeforeUnmount(() => {
 
 .time-column div {
   padding: 8px;
-  cursor: pointer;
   text-align: center;
   font-size: 20px;
 }
@@ -548,6 +548,7 @@ onBeforeUnmount(() => {
   background-color: #cce5ff;
   font-weight: bold;
   border-radius: 4px;
+  width: 15vw;
 }
 
 .colon {
@@ -562,6 +563,12 @@ onBeforeUnmount(() => {
   margin-top: 30px;
   border-top: 1px solid #ccc;
   padding-top: 8px;
+  margin-left: -1rem;
+  margin-right: -1rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  width: calc(100% + 2rem);
+  box-sizing: border-box;
 }
 
 .time-buttons button {

--- a/pages/ReservationForm.vue
+++ b/pages/ReservationForm.vue
@@ -48,6 +48,14 @@ const formattedDate = computed(() => {
   return `${month}月${day}日(${weekday})`
 })
 
+function getDayClass(day) {
+  const date = new Date(year.value, month.value, day)
+  const weekday = date.getDay()
+  if (weekday === 0) return 'sunday'
+  if (weekday === 6) return 'saturday'
+  return ''
+}
+
 function selectDate(day) {
   selectedDate.value = `${year.value}-${String(month.value + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`
 }
@@ -143,7 +151,7 @@ const showTimePicker = ref(false)
 const selectedHour = ref('')
 const selectedMinute = ref('')
 
-const hours = Array.from({ length: 24 }, (_, i) => String(i).padStart(2, '0'))
+const hours = Array.from({ length: 6 }, (_, i) => String(i + 17).padStart(2, '0'))
 const minutes = Array.from({ length: 12 }, (_, i) => String(i * 5).padStart(2, '0'))
 
 function openCustomTimePicker() {
@@ -224,7 +232,16 @@ onBeforeUnmount(() => {
             <button type="button" @click="nextMonth">›</button>
           </div>
           <div class="weekdays">
-            <span v-for="w in weekdays" :key="w">{{ w }}</span>
+            <span
+              v-for="(w, i) in weekdays"
+              :key="w"
+              :class="{
+                sunday: i === 0,
+                saturday: i === 6
+              }"
+            >
+              {{ w }}
+            </span>
           </div>
           <div class="days">
             <span v-for="n in firstDay" :key="'blank' + n"></span>
@@ -232,10 +249,10 @@ onBeforeUnmount(() => {
               v-for="d in daysInMonth"
               :key="d"
               @click="selectDate(d)"
-              :class="{
-              today: isToday(d),
-              selected: isSelected(d)
-              }"
+              :class="[
+                { today: isToday(d), selected: isSelected(d) },
+                getDayClass(d)
+              ]"
             >
               {{ d }}
             </span>
@@ -268,34 +285,19 @@ onBeforeUnmount(() => {
           <span class="label-text">時間</span>
           <span class="required-mark">＊</span>
         </label>
-        <input
-          type="text"
-          id="time"
-          :value="formData.time"
-          readonly
-          @click="openCustomTimePicker"
-        />
+        <input type="text" id="time" :value="formData.time" readonly @click="openCustomTimePicker" />
         <div v-if="showTimePicker" class="time-picker" ref="timePickerRef">
           <div class="time-highlight"></div>
           <div class="time-columns">
             <div class="time-column">
-              <div
-                v-for="h in hours"
-                :key="h"
-                :class="{ selected: h === selectedHour }"
-                @click="selectedHour = h"
-              >
+              <div v-for="h in hours" :key="h" :class="{ selected: h === selectedHour }" @click="selectedHour = h">
                 {{ h }}
               </div>
             </div>
             <span class="colon">:</span>
             <div class="time-column">
-              <div
-                v-for="m in minutes"
-                :key="m"
-                :class="{ selected: m === selectedMinute }"
-                @click="selectedMinute = m"
-              >
+              <div v-for="m in minutes" :key="m" :class="{ selected: m === selectedMinute }"
+                @click="selectedMinute = m">
                 {{ m }}
               </div>
             </div>
@@ -391,7 +393,9 @@ onBeforeUnmount(() => {
   font-size: 20px;
   z-index: 1000;
   border-radius: 15px;
-  font-family: "Noto Sans JP";
+  /*font-family: "Noto Sans JP";*/
+  /*font-family: sans-serif;*/
+  font-family: Arial;
 }
 
 .header {
@@ -430,9 +434,23 @@ onBeforeUnmount(() => {
   color: rgb(164, 164, 164);
 }
 
+.weekdays .sunday {
+  color: red;
+}
+
+.weekdays .saturday {
+  color: blue;
+}
+
 .days span {
-  cursor: pointer;
-  padding: 0.65rem;
+  /*cursor: pointer;
+  padding: 0.65rem;*/
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 45px;
+  /* 固定高さを設定 */
+  box-sizing: border-box;
 }
 
 .days span.today {
@@ -441,7 +459,7 @@ onBeforeUnmount(() => {
 }
 
 .days span.today:not(.selected) {
-  color: #007bff;
+  color: rgb(0, 130, 255);
   font-weight: bold;
 }
 
@@ -454,7 +472,15 @@ onBeforeUnmount(() => {
 
 .days span.today.selected {
   color: white;
-  background-color: blue;
+  background-color: rgb(42, 152, 254);
+}
+
+.days .sunday {
+  color: red;
+}
+
+.days .saturday {
+  color: blue;
 }
 
 .calender-buttons {


### PR DESCRIPTION
日付入力欄カレンダーの微調整と、時間入力欄ピッカーの作成を行いました。

日付入力欄カレンダー
・input="date"の時にスマホで表示されるカレンダーのように微調整
・フォントやフォントサイズの指定
・機種の違いによる曜日の文字と日付の文字の位置がずれてしまうバグの修正
・曜日の文字を日にちと比較して小さく修正

時間入力欄ピッカー
・ほかのところをタップすると時間入力ピッカーが閉じる
・とりあえず選択式方法の採用
・時間入力範囲を17時00分～22時55分に変更
・完了ボタンを押さなくても、選択したら入力欄に表示される