### PR TITLE
ダブルクリック防止改善案

### DIFF
--- a/pages/ConfirmShift.vue
+++ b/pages/ConfirmShift.vue
@@ -7,6 +7,7 @@ const router = useRouter()
 const route = useRoute()
 const shiftData = ref([])
 const startDate = ref('')
+const isSubmitting = ref(false)
 
 const client = createClient({
   serviceDomain: import.meta.env.VITE_SHIFT_DOMAIN,
@@ -59,6 +60,9 @@ const goBackWithDate = () => {
 }
 
 const submitShift = async () => {
+  if (isSubmitting.value) return
+  isSubmitting.value = true
+
   try {
     const allDates = shiftData.value.map((_, i) => getDateWithOffset(i));
 
@@ -111,6 +115,8 @@ const submitShift = async () => {
       : '/ReservationTableCompact');
   } catch (e) {
     alert(e.message || 'エラーが発生しました');
+  } finally {
+    isSubmitting.value = false
   }
 };
 </script>
@@ -129,7 +135,9 @@ const submitShift = async () => {
     </div>
     <div class="button-container">
       <button @click="goBackWithDate" class="go-back-btn">戻る</button>
-      <button @click="submitShift" class="go-back-btn">送信</button>
+      <button @click="submitShift" :disabled="isSubmitting" class="submit-btn">
+        {{ isSubmitting ? '送信中...' : '送信' }}
+      </button>
     </div>
   </div>
 </template>
@@ -183,5 +191,23 @@ li {
   font-size: 17px;
   font-weight: bold;
 }
-</style>
 
+.submit-btn {
+  width: 130px;
+  height: 45px;
+  color: black;
+  background-color: #fbc02d;
+  border: 2px solid #fbc02d;
+  border-radius: 12px;
+  cursor: pointer;
+  font-size: 17px;
+  font-weight: bold;
+}
+
+.submit-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background-color: #ccc;
+  border-color: #ccc;
+}
+</style>

--- a/pages/Signup.vue
+++ b/pages/Signup.vue
@@ -11,6 +11,7 @@ const confirmPassword = ref('')
 const errorMessage = ref('')
 const showPassword = ref(false)
 const showConfirmPassword = ref(false)
+const isSubmitting = ref(false)
 
 const { signup } = useAuth()
 const router = useRouter()
@@ -24,33 +25,42 @@ const toggleConfirmPasswordVisibility = () => {
 }
 
 const handleSignup = async () => {
+  if (isSubmitting.value) return
+  isSubmitting.value = true
+
   if (!email.value) {
     errorMessage.value = 'メールアドレスが入力されていません。'
+    isSubmitting.value = false
     return
   }
 
   if (!username.value) {
     errorMessage.value = 'ユーザーネームが入力されていません。'
+    isSubmitting.value = false
     return
   }
 
   if (!password.value) {
     errorMessage.value = 'パスワードが入力されていません。'
+    isSubmitting.value = false
     return
   }
 
   if (!confirmPassword.value) {
     errorMessage.value = 'パスワード(確認用)が入力されていません。'
+    isSubmitting.value = false
     return
   }
 
   if (!isValidBirthdayFormat(password.value)) {
     errorMessage.value = 'パスワードの形式が正しくありません。'
+    isSubmitting.value = false
     return
   }
 
   if(password.value !== confirmPassword.value){
     errorMessage.value = 'パスワードが一致しません。'
+    isSubmitting.value = false
     return
   }
 
@@ -64,6 +74,8 @@ const handleSignup = async () => {
     } else {
       errorMessage.value = 'アカウント作成に失敗しました。'
     }
+  } finally {
+    isSubmitting.value = false
   }
 }
 </script>
@@ -108,7 +120,9 @@ const handleSignup = async () => {
         </button>
       </div>
       <span class="error-message" v-if="errorMessage">{{ errorMessage }}</span>
-      <button class="signup-button">アカウント作成</button>
+      <button :disabled="isSubmitting" class="signup-button">
+        {{ isSubmitting ? 'アカウント作成中...' : 'アカウント作成' }}
+      </button>
     </form>
     <p class="link-text">
       すでにアカウントをお持ちの方は
@@ -222,6 +236,12 @@ form {
   cursor: pointer;
   margin-top: 25px;
   transition: background-color 0.3s;
+}
+
+.signup-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background-color: #ccc;
 }
 
 .link-text {


### PR DESCRIPTION
・ConfirmShift.vueページで、データを送信する際に時間がかかるので、ダブルクリックしてしまうことを防止する案の提案になります。

・Signup.vueページで、アカウントを作成する際に時間がかかるので、ダブルクリックしてしまうことを防止する案の提案になります。検証する際、現在のstagingブランチでアカウント作成画面にいき、入力欄を埋めたら、高速で2回クリックすると同じアカウントが作成されるので、その問題の解消になります。アカウント作成後は、firebaseのAuthenticationとDatabaseそれぞれのデータを削除してください。