### PR TITLE
予約送信と予約閲覧でのデータベース移行

### DIFF
--- a/pages/ConfirmReservation.vue
+++ b/pages/ConfirmReservation.vue
@@ -1,7 +1,6 @@
 <script setup>
 import { reactive, onMounted, computed } from 'vue'
 import { useRouter } from 'vue-router'
-import { createClient } from 'microcms-js-sdk'
 
 const router = useRouter()
 const formData = reactive({
@@ -13,11 +12,6 @@ const formData = reactive({
   info: '',
   phone: '',
   seat: '',
-})
-
-const client = createClient({
-  serviceDomain: import.meta.env.VITE_MICROCMS_SERVICE_DOMAIN,
-  apiKey: import.meta.env.VITE_API_KEY,
 })
 
 const formattedPhone = computed(() => {
@@ -35,16 +29,19 @@ onMounted(() => {
   }
 })
 
-const submitReservation = () => {
+const submitReservation = async () => {
   if (confirm('予約を確定しますか？')) {
     const combinedTime = formData.date && formData.time
-      ? `${formData.date} ${formData.time}`
+      ? `${formData.date}T${formData.time}:00.000Z`
       : formData.time || '';
 
-    client
-      .create({
-        endpoint: 'data',
-        content: {
+    try {
+      const response = await fetch('/api/reservations', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
           name: formData.name,
           people: formData.people,
           time: combinedTime,
@@ -53,19 +50,23 @@ const submitReservation = () => {
           info: formData.info,
           phone: formData.phone,
           seat: formData.seat,
-        },
+        }),
       })
-      .then(() => {
-        // 日付をクエリとして渡して予約表に遷移
-        if (formData.date) {
-          router.push(`/ReservationTableCompact?date=${formData.date}`);
-        } else {
-          router.push('/ReservationTableCompact');
-        }
-      })
-      .catch((error) => {
-        console.error('送信エラー:', error);
-      });
+
+      if (!response.ok) {
+        throw new Error('予約の作成に失敗しました');
+      }
+
+      // 日付をクエリとして渡して予約表に遷移
+      if (formData.date) {
+        router.push(`/ReservationTableCompact?date=${formData.date}`);
+      } else {
+        router.push('/ReservationTableCompact');
+      }
+    } catch (error) {
+      console.error('送信エラー:', error);
+      alert('予約の作成に失敗しました');
+    }
   };
 }
 

--- a/pages/ReservationTableCompact.vue
+++ b/pages/ReservationTableCompact.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, onMounted} from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { createClient } from 'microcms-js-sdk'
 import { sortTime } from '../utils/sortTime.js'
 import { addCourseDrink } from '../utils/addCourseDrink.js'
@@ -21,11 +21,6 @@ const goToDetail = (reservation) => {
   router.push('/ReservationDetail');
 };
 
-const reservationClient = createClient({
-  serviceDomain: import.meta.env.VITE_MICROCMS_SERVICE_DOMAIN,
-  apiKey: import.meta.env.VITE_API_KEY,
-})
-
 const shiftClient = createClient({
   serviceDomain: import.meta.env.VITE_SHIFT_DOMAIN,
   apiKey: import.meta.env.VITE_SHIFT_API_KEY,
@@ -37,17 +32,25 @@ const shiftList = ref([]);
 const inputDate = ref('');
 const activeSort = ref('');
 
-reservationClient.getList({
-  endpoint: 'data',
-  queries: { limit: 100 }
-})
-.then((res) => {
-   originalReservations.value = reverseArray(res.contents);
-  reservations.value = [...originalReservations.value];
-})
-.catch((err) => console.error(err))
+// Firestoreから予約データを取得（onMountedで実行）
+const fetchReservations = async () => {
+  try {
+    const response = await fetch('/api/reservations')
+    if (!response.ok) {
+      throw new Error('予約データの取得に失敗しました')
+    }
+    const data = await response.json()
+    originalReservations.value = reverseArray(data.reservations);
+    reservations.value = [...originalReservations.value];
+  } catch (err) {
+    console.error('予約データ取得エラー:', err)
+  }
+}
 
-onMounted(() => {
+onMounted(async () => {
+  // 予約データを取得
+  await fetchReservations()
+
   if (!inputDate.value) {
     const now = new Date()
     inputDate.value = new Date(now.getTime() + 9 * 60 * 60 * 1000).toISOString().split('T')[0]
@@ -71,20 +74,27 @@ shiftClient.getList({
 .catch((err) => console.error(err))
 
 const filteredReservations = computed(() => {
+  let filtered;
+
   if (!inputDate.value) {
-    return reservations.value.filter((reservation) => reservation.info !== '休み');
+    // 休みという情報を持つ予約を除外する
+    filtered = reservations.value.filter((reservation) => reservation.info !== '休み');
+  } else {
+    filtered = reservations.value.filter((reservation) => {
+      const reservationDate = reservation.time?.split('T')[0];
+      return reservationDate && inputDate.value === reservationDate && reservation.info !== '休み';
+    });
   }
-  return reservations.value.filter((reservation) => {
-    const reservationDate = reservation.time.split('T')[0];
-    return inputDate.value === reservationDate && reservation.info !== '休み';
-  });
+
+  return filtered;
 });
 
 const isHoliday = computed(() => {
   if (!inputDate.value) return false;
   return reservations.value.some((reservation) => {
-    const reservationDate = reservation.time.split('T')[0];
-    return inputDate.value === reservationDate && reservation.info === '休み';
+    const reservationDate = reservation.time?.split('T')[0];
+    // 特定の日で、予約データのinfoが”休み”というのが1つでもあったらtrueを返す
+    return reservationDate && inputDate.value === reservationDate && reservation.info === '休み';
   });
 });
 
@@ -110,6 +120,11 @@ function handleSort(type, sortFunction) {
     sortFunction(reservations.value);
     activeSort.value = type;
   }
+}
+
+function getTimeFromReservation(timeString) {
+  if (!timeString) return '';
+  return timeString.split('T')[1]?.slice(0, 5) || '';
 }
 
 function reverseArray(arr) {
@@ -186,7 +201,7 @@ function goToNewReservation() {
           <tr v-for="reservation in filteredReservations" :key="reservation.id" @click="goToDetail(reservation)">
             <td class="name-space">{{ reservation.name }}</td>
             <td class="number-space">{{ reservation.people }}</td>
-            <td class="time-space">{{ reservation.time.split('T')[1].slice(0, 5) }}</td>
+            <td class="time-space">{{ getTimeFromReservation(reservation.time) }}</td>
             <td class="seat-space">{{ reservation.seat }}</td>
             <td class="info-space">
               <div>

--- a/server/api/reservations/index.get.ts
+++ b/server/api/reservations/index.get.ts
@@ -1,0 +1,33 @@
+import { adminDb } from '../../firebase/admin'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const snapshot = await adminDb.collection('reservations').get()
+
+    const reservations = snapshot.docs.map(doc => {
+      const data = doc.data()
+      return {
+        id: doc.id,
+        name: data.name,
+        people: data.people,
+        time: data.time,
+        course: data.course,
+        drink: data.drink,
+        info: data.info,
+        phone: data.phone,
+        seat: data.seat,
+        createdBy: data.createdBy,
+        createdAt: data.createdAt?.toDate().toISOString(),
+        updatedAt: data.updatedAt?.toDate().toISOString(),
+      }
+    })
+
+    return { reservations }
+  } catch (error) {
+    console.error('予約取得エラー:', error)
+    throw createError({
+      statusCode: 500,
+      message: '予約データの取得に失敗しました'
+    })
+  }
+})

--- a/server/api/reservations/index.post.ts
+++ b/server/api/reservations/index.post.ts
@@ -1,0 +1,86 @@
+import { adminDb } from '../../firebase/admin'
+import { FieldValue } from 'firebase-admin/firestore'
+import { getAuth } from 'firebase-admin/auth'
+import { parseCookies } from 'h3'
+
+export default defineEventHandler(async (event) => {
+  // セッション検証
+  const cookies = parseCookies(event)
+  const sessionCookie = cookies.__session
+
+  if (!sessionCookie) {
+    throw createError({
+      statusCode: 401,
+      message: 'ログインが必要です',
+    })
+  }
+
+  let decodedClaims
+  try {
+    decodedClaims = await getAuth().verifySessionCookie(sessionCookie, true)
+  } catch (e) {
+    throw createError({
+      statusCode: 401,
+      message: 'セッションが無効です',
+    })
+  }
+
+  // ユーザー情報を取得
+  const userDoc = await adminDb.collection('users').doc(decodedClaims.uid).get()
+  const userData = userDoc.data()
+
+  if (!userData) {
+    throw createError({
+      statusCode: 404,
+      message: 'ユーザー情報が見つかりません',
+    })
+  }
+
+  const body = await readBody(event)
+  const { name, people, time, course, drink, info, phone, seat } = body
+
+  // バリデーション
+  if (!name || !people || !time || !phone) {
+    throw createError({
+      statusCode: 400,
+      message: '必須項目が不足しています (name, people, time, phone)',
+    })
+  }
+
+  // Firestoreに予約データを送信
+  try {
+    const docRef = await adminDb.collection('reservations').add({
+      name,
+      people,
+      time,
+      course: Array.isArray(course) ? course : [course || 'なし'],
+      drink: Array.isArray(drink) ? drink : [drink || 'なし'],
+      info: info || '',
+      phone,
+      seat: seat || '',
+      createdBy: {
+        uid: decodedClaims.uid,
+        email: decodedClaims.email,
+        username: userData.username,
+      },
+      createdAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    })
+
+    return {
+      id: docRef.id,
+      message: '予約が作成されました',
+      createdBy: {
+        uid: decodedClaims.uid,
+        email: decodedClaims.email,
+        username: userData.username,
+      },
+    }
+  } catch (error) {
+    console.error('予約作成エラー:', error)
+    throw createError({
+      statusCode: 500,
+      message: '予約の作成に失敗しました',
+    })
+  }
+})

--- a/types/reservation.ts
+++ b/types/reservation.ts
@@ -1,0 +1,72 @@
+import { Timestamp } from 'firebase/firestore'
+
+/**
+ * Firestore予約データの型定義
+ */
+export interface Reservation {
+  id: string                    // FirestoreドキュメントID
+  name: string                  // 予約者名
+  people: string                // 人数
+  time: string                  // ISO 8601形式 (例: "2024-12-25T18:00:00.000Z")
+  course: string[]              // コース(配列)
+  drink: string[]               // 飲み放題オプション(配列)
+  info: string                  // 詳細情報・備考
+  phone: string                 // 携帯電話番号 (11桁)
+  seat: string                  // 席番号
+  createdBy: {                  // 作成者情報
+    uid: string                 // ユーザーID
+    email: string               // メールアドレス
+    username: string            // ユーザー名
+  }
+  createdAt: Date               // 作成日時
+  updatedAt: Date               // 更新日時
+}
+
+/**
+ * 予約作成時の入力型 (Firestore保存用)
+ */
+export interface CreateReservationInput {
+  name: string
+  people: string
+  time: string
+  course: string[]
+  drink: string[]
+  info: string
+  phone: string
+  seat: string
+}
+
+/**
+ * 予約更新時の入力型 (すべてオプショナル)
+ */
+export interface UpdateReservationInput {
+  name?: string
+  people?: string
+  time?: string
+  course?: string[]
+  drink?: string[]
+  info?: string
+  phone?: string
+  seat?: string
+}
+
+/**
+ * Firestoreドキュメント型 (Timestamp含む)
+ */
+export interface ReservationDocument {
+  name: string
+  people: string
+  time: string
+  course: string[]
+  drink: string[]
+  info: string
+  phone: string
+  seat: string
+  createdBy: {
+    uid: string
+    email: string
+    username: string
+  }
+  createdAt: Timestamp
+  updatedAt: Timestamp
+}


### PR DESCRIPTION
予約送信と予約閲覧で使うデータベースをmicroCMSからFirestoreに移行しました。

現段階では以下の状態です。
・予約を入力し、送信するとサーバーを通してFirestore上に予約データが格納される。（予約を作成したユーザーの名前も格納されている）
・予約表に、Firestoreから持ってきた予約データを表示することができている。

※このプルリクの目的はデータベースの移行になります。