### PR TITLE
休み設定機能でのデータベース移行（microCMSからFirestoreに移行）

### DIFF
--- a/pages/HolidaySettings.vue
+++ b/pages/HolidaySettings.vue
@@ -1,16 +1,10 @@
 <script setup>
-import { ref, computed, onMounted } from 'vue'
-import { createClient } from 'microcms-js-sdk'
+import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import DateRangePicker from '../components/DateRangePicker.vue'
 import BottomNavigation from '../components/BottomNavigation.vue'
 
 const router = useRouter()
-
-const client = createClient({
-  serviceDomain: import.meta.env.VITE_MICROCMS_SERVICE_DOMAIN,
-  apiKey: import.meta.env.VITE_API_KEY,
-})
 
 const startDate = ref('')
 const endDate = ref('')
@@ -21,86 +15,25 @@ const editingPeriod = ref(null)
 const editStartDate = ref('')
 const editEndDate = ref('')
 const isEditCalendarOpen = ref(false)
-const deletingPeriodIndex = ref(null)
+const deletingPeriodId = ref(null)
 const showEditButtons = ref(false)
 
 async function fetchHolidays() {
   try {
-    const res = await client.getList({
-      endpoint: 'data',
-      queries: {
-        limit: 100,
-        filters: 'info[equals]休み'
-      }
-    })
+    const response = await fetch('/api/holidays')
+    if (!response.ok) {
+      throw new Error('休みデータの取得に失敗しました')
+    }
 
-    console.log('取得した休みデータ:', res.contents)
+    const data = await response.json()
+    holidays.value = data.holidays
 
-    const holidayData = res.contents
-      .filter(item => item.info === '休み')
-      .map(item => ({
-        id: item.id,
-        date: item.time.split('T')[0]
-      }))
-      .sort((a, b) => a.date.localeCompare(b.date))
-
-    console.log('グループ化前のデータ:', holidayData)
-    holidays.value = holidayData
+    console.log('取得した休みデータ:', holidays.value)
   } catch (error) {
-    alert('休みデータの取得に失敗しました:' + error)
+    console.error('休みデータ取得エラー:', error)
+    alert('休みデータの取得に失敗しました: ' + error.message)
   }
 }
-
-const holidayPeriods = computed(() => {
-  if (holidays.value.length === 0) return []
-
-  const uniqueDates = {}
-  holidays.value.forEach(item => {
-    if (!uniqueDates[item.date]) {
-      uniqueDates[item.date] = item.id
-    }
-  })
-
-  const uniqueHolidays = Object.keys(uniqueDates)
-    .map(date => ({
-      date: date,
-      id: uniqueDates[date]
-    }))
-    .sort((a, b) => a.date.localeCompare(b.date))
-
-  if (uniqueHolidays.length === 0) return []
-
-  const periods = []
-  let currentPeriod = {
-    startDate: uniqueHolidays[0].date,
-    endDate: uniqueHolidays[0].date,
-    ids: [uniqueHolidays[0].id]
-  }
-
-  for (let i = 1; i < uniqueHolidays.length; i++) {
-    const prevDate = new Date(uniqueHolidays[i - 1].date)
-    const currDate = new Date(uniqueHolidays[i].date)
-    const diffDays = (currDate - prevDate) / (1000 * 60 * 60 * 24)
-
-    if (diffDays === 1) {
-      // 連続している
-      currentPeriod.endDate = uniqueHolidays[i].date
-      currentPeriod.ids.push(uniqueHolidays[i].id)
-    } else {
-      // 連続していない
-      periods.push(currentPeriod)
-      currentPeriod = {
-        startDate: uniqueHolidays[i].date,
-        endDate: uniqueHolidays[i].date,
-        ids: [uniqueHolidays[i].id]
-      }
-    }
-  }
-
-  periods.push(currentPeriod)
-  console.log('グループ化後の期間:', periods)
-  return periods
-})
 
 // 日付フォーマット
 function formatDate(dateStr) {
@@ -132,69 +65,29 @@ function handleEditCalendarToggle(isOpen) {
   isEditCalendarOpen.value = isOpen
 }
 
-// 日付の重複チェック
-function checkDateOverlap(newStartDate, newEndDate) {
-  const newStart = new Date(newStartDate)
-  const newEnd = new Date(newEndDate)
-
-  // 既存の休みデータと重複チェック
-  for (const holiday of holidays.value) {
-    const existingDate = new Date(holiday.date)
-
-    // 新規期間に既存の日付が含まれているかチェック
-    if (existingDate >= newStart && existingDate <= newEnd) {
-      return true
-    }
-  }
-
-  return false
-}
-
 async function saveHolidaySettings() {
   if (!startDate.value || !endDate.value) {
     alert('開始日と終了日を選択してください')
     return
   }
 
-  // 重複チェック
-  if (checkDateOverlap(startDate.value, endDate.value)) {
-    alert('選択した期間は既に休み設定されています')
-    return
-  }
-
   isSubmitting.value = true
 
   try {
-    const start = new Date(startDate.value)
-    const end = new Date(endDate.value)
+    const response = await fetch('/api/holidays', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        startDate: startDate.value,
+        endDate: endDate.value,
+      }),
+    })
 
-    // 開始日から終了日までの各日付に対してデータを作成（順次実行で遅延を入れる）
-    const currentDate = new Date(start)
-
-    while (currentDate <= end) {
-      const dateStr = currentDate.toISOString().split('T')[0]
-      const timeStr = `${dateStr}T00:00:00`
-
-      const holidayData = {
-        name: '-',
-        people: '-',
-        time: timeStr,
-        seat: '-',
-        course: ['-'],
-        drink: ['-'],
-        phone: '-',
-        info: '休み'
-      }
-
-      await client.create({
-        endpoint: 'data',
-        content: holidayData
-      })
-
-      // レート制限回避のため100ms待機
-      await new Promise(resolve => setTimeout(resolve, 100))
-
-      currentDate.setDate(currentDate.getDate() + 1)
+    if (!response.ok) {
+      const errorData = await response.json()
+      throw new Error(errorData.message || '休み設定の保存に失敗しました')
     }
 
     alert('休み設定を保存しました')
@@ -205,8 +98,8 @@ async function saveHolidaySettings() {
       query: { date: startDate.value }
     })
   } catch (error) {
-    alert('休み設定の保存に失敗しました:' + error)
-    alert('休み設定の保存に失敗しました')
+    console.error('休み設定保存エラー:', error)
+    alert(error.message || '休み設定の保存に失敗しました')
   } finally {
     isSubmitting.value = false
   }
@@ -245,45 +138,20 @@ async function updatePeriod() {
   isSubmitting.value = true
 
   try {
-    // 既存の期間を削除（順次実行で遅延を入れる）
-    for (const id of editingPeriod.value.ids) {
-      await client.delete({
-        endpoint: 'data',
-        contentId: id
-      })
-      // レート制限回避のため100ms待機
-      await new Promise(resolve => setTimeout(resolve, 100))
-    }
+    const response = await fetch(`/api/holidays/${editingPeriod.value.id}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        startDate: editStartDate.value,
+        endDate: editEndDate.value,
+      }),
+    })
 
-    // 新しい期間を作成（順次実行で遅延を入れる）
-    const start = new Date(editStartDate.value)
-    const end = new Date(editEndDate.value)
-    const currentDate = new Date(start)
-
-    while (currentDate <= end) {
-      const dateStr = currentDate.toISOString().split('T')[0]
-      const timeStr = `${dateStr}T00:00:00`
-
-      const holidayData = {
-        name: '-',
-        people: '-',
-        time: timeStr,
-        seat: '-',
-        course: ['-'],
-        drink: ['-'],
-        phone: '-',
-        info: '休み'
-      }
-
-      await client.create({
-        endpoint: 'data',
-        content: holidayData
-      })
-
-      // レート制限回避のため100ms待機
-      await new Promise(resolve => setTimeout(resolve, 100))
-
-      currentDate.setDate(currentDate.getDate() + 1)
+    if (!response.ok) {
+      const errorData = await response.json()
+      throw new Error(errorData.message || '休み設定の更新に失敗しました')
     }
 
     alert('休み設定を更新しました')
@@ -294,30 +162,29 @@ async function updatePeriod() {
     // 編集モードを終了
     cancelEdit()
   } catch (error) {
-    alert('休み設定の更新に失敗しました:' + error)
-    alert('休み設定の更新に失敗しました')
+    console.error('休み設定更新エラー:', error)
+    alert(error.message || '休み設定の更新に失敗しました')
   } finally {
     isSubmitting.value = false
   }
 }
 
 // 期間を削除
-async function deletePeriod(period, index) {
+async function deletePeriod(period) {
   if (!confirm(`${formatPeriod(period)} の休み設定を削除しますか？`)) {
     return
   }
 
-  deletingPeriodIndex.value = index
+  deletingPeriodId.value = period.id
 
   try {
-    // 順次実行で遅延を入れる
-    for (const id of period.ids) {
-      await client.delete({
-        endpoint: 'data',
-        contentId: id
-      })
-      // レート制限回避のため100ms待機
-      await new Promise(resolve => setTimeout(resolve, 100))
+    const response = await fetch(`/api/holidays/${period.id}`, {
+      method: 'DELETE',
+    })
+
+    if (!response.ok) {
+      const errorData = await response.json()
+      throw new Error(errorData.message || '休み設定の削除に失敗しました')
     }
 
     alert('休み設定を削除しました')
@@ -325,10 +192,10 @@ async function deletePeriod(period, index) {
     // データを再取得
     await fetchHolidays()
   } catch (error) {
-    alert('休み設定の削除に失敗しました:' + error)
-    alert('休み設定の削除に失敗しました')
+    console.error('休み設定削除エラー:', error)
+    alert(error.message || '休み設定の削除に失敗しました')
   } finally {
-    deletingPeriodIndex.value = null
+    deletingPeriodId.value = null
   }
 }
 
@@ -417,14 +284,14 @@ onMounted(() => {
     <div class="content section existing-section">
       <h2 class="section-title">既存の休み設定</h2>
 
-      <div v-if="holidayPeriods.length === 0" class="no-data">
+      <div v-if="holidays.length === 0" class="no-data">
         登録されている休み設定はありません
       </div>
 
       <div v-else class="holiday-list">
         <div
-          v-for="(period, index) in holidayPeriods"
-          :key="index"
+          v-for="period in holidays"
+          :key="period.id"
           class="holiday-item"
         >
           <div class="period-info">
@@ -435,17 +302,17 @@ onMounted(() => {
               type="button"
               class="edit-btn"
               @click="startEdit(period)"
-              :disabled="deletingPeriodIndex !== null"
+              :disabled="deletingPeriodId !== null"
             >
               編集
             </button>
             <button
               type="button"
               class="delete-btn"
-              @click="deletePeriod(period, index)"
-              :disabled="deletingPeriodIndex !== null"
+              @click="deletePeriod(period)"
+              :disabled="deletingPeriodId !== null"
             >
-              {{ deletingPeriodIndex === index ? '削除中...' : '削除' }}
+              {{ deletingPeriodId === period.id ? '削除中...' : '削除' }}
             </button>
           </div>
         </div>

--- a/server/api/holidays/[id].delete.ts
+++ b/server/api/holidays/[id].delete.ts
@@ -1,0 +1,74 @@
+import { adminDb } from '../../firebase/admin'
+import { getAuth } from 'firebase-admin/auth'
+import { parseCookies } from 'h3'
+
+export default defineEventHandler(async (event) => {
+  // セッション検証
+  const cookies = parseCookies(event)
+  const sessionCookie = cookies.__session
+
+  if (!sessionCookie) {
+    throw createError({
+      statusCode: 401,
+      message: 'ログインが必要です',
+    })
+  }
+
+  let decodedClaims
+  try {
+    decodedClaims = await getAuth().verifySessionCookie(sessionCookie, true)
+  } catch (e) {
+    throw createError({
+      statusCode: 401,
+      message: 'セッションが無効です',
+    })
+  }
+
+  const id = event.context.params?.id
+  if (!id) {
+    throw createError({
+      statusCode: 400,
+      message: 'IDが指定されていません',
+    })
+  }
+
+  try {
+    // 削除対象のドキュメントが存在するか確認
+    const docRef = adminDb.collection('reservations').doc(id)
+    const doc = await docRef.get()
+
+    if (!doc.exists) {
+      throw createError({
+        statusCode: 404,
+        message: '指定された休み設定が見つかりません',
+      })
+    }
+
+    const docData = doc.data()
+    if (docData?.info !== '休み') {
+      throw createError({
+        statusCode: 400,
+        message: '指定されたIDは休み設定ではありません',
+      })
+    }
+
+    // 休み設定を削除
+    await docRef.delete()
+
+    return {
+      id,
+      message: '休み設定が削除されました',
+    }
+  } catch (error: any) {
+    // 既に createError でスローされたエラーはそのまま再スロー
+    if (error.statusCode) {
+      throw error
+    }
+
+    console.error('休み設定削除エラー:', error)
+    throw createError({
+      statusCode: 500,
+      message: '休み設定の削除に失敗しました',
+    })
+  }
+})

--- a/server/api/holidays/[id].put.ts
+++ b/server/api/holidays/[id].put.ts
@@ -1,0 +1,151 @@
+import { adminDb } from '../../firebase/admin'
+import { FieldValue } from 'firebase-admin/firestore'
+import { getAuth } from 'firebase-admin/auth'
+import { parseCookies } from 'h3'
+
+export default defineEventHandler(async (event) => {
+  // セッション検証
+  const cookies = parseCookies(event)
+  const sessionCookie = cookies.__session
+
+  if (!sessionCookie) {
+    throw createError({
+      statusCode: 401,
+      message: 'ログインが必要です',
+    })
+  }
+
+  let decodedClaims
+  try {
+    decodedClaims = await getAuth().verifySessionCookie(sessionCookie, true)
+  } catch (e) {
+    throw createError({
+      statusCode: 401,
+      message: 'セッションが無効です',
+    })
+  }
+
+  // ユーザー情報を取得
+  const userDoc = await adminDb.collection('users').doc(decodedClaims.uid).get()
+  const userData = userDoc.data()
+
+  if (!userData) {
+    throw createError({
+      statusCode: 404,
+      message: 'ユーザー情報が見つかりません',
+    })
+  }
+
+  const id = event.context.params?.id
+  if (!id) {
+    throw createError({
+      statusCode: 400,
+      message: 'IDが指定されていません',
+    })
+  }
+
+  const body = await readBody(event)
+  const { startDate, endDate } = body
+
+  // バリデーション
+  if (!startDate || !endDate) {
+    throw createError({
+      statusCode: 400,
+      message: '必須項目が不足しています (startDate, endDate)',
+    })
+  }
+
+  // 日付の妥当性チェック
+  const start = new Date(startDate)
+  const end = new Date(endDate)
+
+  if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+    throw createError({
+      statusCode: 400,
+      message: '日付の形式が不正です',
+    })
+  }
+
+  if (start > end) {
+    throw createError({
+      statusCode: 400,
+      message: '開始日は終了日より前である必要があります',
+    })
+  }
+
+  try {
+    // 更新対象のドキュメントが存在するか確認
+    const docRef = adminDb.collection('reservations').doc(id)
+    const doc = await docRef.get()
+
+    if (!doc.exists) {
+      throw createError({
+        statusCode: 404,
+        message: '指定された休み設定が見つかりません',
+      })
+    }
+
+    const docData = doc.data()
+    if (docData?.info !== '休み') {
+      throw createError({
+        statusCode: 400,
+        message: '指定されたIDは休み設定ではありません',
+      })
+    }
+
+    // 重複チェック: 自分以外の休み設定と期間が重複していないか確認
+    const existingHolidays = await adminDb
+      .collection('reservations')
+      .where('info', '==', '休み')
+      .get()
+
+    for (const existingDoc of existingHolidays.docs) {
+      // 自分自身はスキップ
+      if (existingDoc.id === id) {
+        continue
+      }
+
+      const data = existingDoc.data()
+      const existingStart = new Date(data.startDate)
+      const existingEnd = new Date(data.endDate)
+
+      // 期間の重複チェック
+      if (
+        (start >= existingStart && start <= existingEnd) ||
+        (end >= existingStart && end <= existingEnd) ||
+        (start <= existingStart && end >= existingEnd)
+      ) {
+        throw createError({
+          statusCode: 409,
+          message: '選択した期間は既に休み設定されています',
+        })
+      }
+    }
+
+    // 休み設定を更新
+    await docRef.update({
+      startDate,
+      endDate,
+      time: `${startDate}T00:00:00`,
+      updatedAt: FieldValue.serverTimestamp(),
+    })
+
+    return {
+      id,
+      message: '休み設定が更新されました',
+      startDate,
+      endDate,
+    }
+  } catch (error: any) {
+    // 既に createError でスローされたエラーはそのまま再スロー
+    if (error.statusCode) {
+      throw error
+    }
+
+    console.error('休み設定更新エラー:', error)
+    throw createError({
+      statusCode: 500,
+      message: '休み設定の更新に失敗しました',
+    })
+  }
+})

--- a/server/api/holidays/[id].put.ts
+++ b/server/api/holidays/[id].put.ts
@@ -122,6 +122,31 @@ export default defineEventHandler(async (event) => {
       }
     }
 
+    // 既存予約チェック: 設定しようとしている期間に既存の予約があるか確認
+    const allReservations = await adminDb
+      .collection('reservations')
+      .where('info', '!=', '休み')
+      .get()
+
+    for (const reservationDoc of allReservations.docs) {
+      const data = reservationDoc.data()
+      // 予約のtime(YYYY-MM-DDTHH:mm:ss形式)から日付部分を取得
+      const reservationDate = new Date(data.time.split('T')[0])
+
+      // 予約日が休み設定期間内にあるかチェック
+      if (reservationDate >= start && reservationDate <= end) {
+        // 日付を「YYYY年M月D日」形式にフォーマット
+        const year = reservationDate.getFullYear()
+        const month = reservationDate.getMonth() + 1
+        const day = reservationDate.getDate()
+        const formattedDate = `${year}年${month}月${day}日`
+        throw createError({
+          statusCode: 409,
+          message: `${formattedDate}に予約が入っているため、休み設定できません`,
+        })
+      }
+    }
+
     // 休み設定を更新
     await docRef.update({
       startDate,

--- a/server/api/holidays/index.get.ts
+++ b/server/api/holidays/index.get.ts
@@ -1,0 +1,32 @@
+import { adminDb } from '../../firebase/admin'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const snapshot = await adminDb
+      .collection('reservations')
+      .where('info', '==', '休み')
+      .get()
+
+    const holidays = snapshot.docs
+      .map(doc => {
+        const data = doc.data()
+        return {
+          id: doc.id,
+          startDate: data.startDate,
+          endDate: data.endDate,
+          createdBy: data.createdBy,
+          createdAt: data.createdAt?.toDate().toISOString(),
+          updatedAt: data.updatedAt?.toDate().toISOString(),
+        }
+      })
+      .sort((a, b) => a.startDate.localeCompare(b.startDate))
+
+    return { holidays }
+  } catch (error) {
+    console.error('休み設定取得エラー:', error)
+    throw createError({
+      statusCode: 500,
+      message: '休み設定の取得に失敗しました'
+    })
+  }
+})

--- a/server/api/holidays/index.post.ts
+++ b/server/api/holidays/index.post.ts
@@ -91,6 +91,31 @@ export default defineEventHandler(async (event) => {
       }
     }
 
+    // 既存予約チェック: 設定しようとしている期間に既存の予約があるか確認
+    const allReservations = await adminDb
+      .collection('reservations')
+      .where('info', '!=', '休み')
+      .get()
+
+    for (const doc of allReservations.docs) {
+      const data = doc.data()
+      // 予約のtime(YYYY-MM-DDTHH:mm:ss形式)から日付部分を取得
+      const reservationDate = new Date(data.time.split('T')[0])
+
+      // 予約日が休み設定期間内にあるかチェック
+      if (reservationDate >= start && reservationDate <= end) {
+        // 日付を「YYYY年M月D日」形式にフォーマット
+        const year = reservationDate.getFullYear()
+        const month = reservationDate.getMonth() + 1
+        const day = reservationDate.getDate()
+        const formattedDate = `${year}年${month}月${day}日`
+        throw createError({
+          statusCode: 409,
+          message: `${formattedDate}に予約が入っているため、休み設定できません`,
+        })
+      }
+    }
+
     // Firestoreに休み設定を保存
     const docRef = await adminDb.collection('reservations').add({
       startDate,

--- a/server/api/holidays/index.post.ts
+++ b/server/api/holidays/index.post.ts
@@ -1,0 +1,139 @@
+import { adminDb } from '../../firebase/admin'
+import { FieldValue } from 'firebase-admin/firestore'
+import { getAuth } from 'firebase-admin/auth'
+import { parseCookies } from 'h3'
+
+export default defineEventHandler(async (event) => {
+  // セッション検証
+  const cookies = parseCookies(event)
+  const sessionCookie = cookies.__session
+
+  if (!sessionCookie) {
+    throw createError({
+      statusCode: 401,
+      message: 'ログインが必要です',
+    })
+  }
+
+  let decodedClaims
+  try {
+    decodedClaims = await getAuth().verifySessionCookie(sessionCookie, true)
+  } catch (e) {
+    throw createError({
+      statusCode: 401,
+      message: 'セッションが無効です',
+    })
+  }
+
+  // ユーザー情報を取得
+  const userDoc = await adminDb.collection('users').doc(decodedClaims.uid).get()
+  const userData = userDoc.data()
+
+  if (!userData) {
+    throw createError({
+      statusCode: 404,
+      message: 'ユーザー情報が見つかりません',
+    })
+  }
+
+  const body = await readBody(event)
+  const { startDate, endDate } = body
+
+  // バリデーション
+  if (!startDate || !endDate) {
+    throw createError({
+      statusCode: 400,
+      message: '必須項目が不足しています (startDate, endDate)',
+    })
+  }
+
+  // 日付の妥当性チェック
+  const start = new Date(startDate)
+  const end = new Date(endDate)
+
+  if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+    throw createError({
+      statusCode: 400,
+      message: '日付の形式が不正です',
+    })
+  }
+
+  if (start > end) {
+    throw createError({
+      statusCode: 400,
+      message: '開始日は終了日より前である必要があります',
+    })
+  }
+
+  // 重複チェック: 既存の休み設定と期間が重複していないか確認
+  try {
+    const existingHolidays = await adminDb
+      .collection('reservations')
+      .where('info', '==', '休み')
+      .get()
+
+    for (const doc of existingHolidays.docs) {
+      const data = doc.data()
+      const existingStart = new Date(data.startDate)
+      const existingEnd = new Date(data.endDate)
+
+      // 期間の重複チェック
+      // 新規期間の開始日が既存期間内、または新規期間の終了日が既存期間内、または新規期間が既存期間を包含
+      if (
+        (start >= existingStart && start <= existingEnd) ||
+        (end >= existingStart && end <= existingEnd) ||
+        (start <= existingStart && end >= existingEnd)
+      ) {
+        throw createError({
+          statusCode: 409,
+          message: '選択した期間は既に休み設定されています',
+        })
+      }
+    }
+
+    // Firestoreに休み設定を保存
+    const docRef = await adminDb.collection('reservations').add({
+      startDate,
+      endDate,
+      info: '休み',
+      // 既存の予約データとの互換性のため、ダミー値を設定
+      name: '-',
+      people: '-',
+      time: `${startDate}T00:00:00`,
+      seat: '-',
+      course: ['-'],
+      drink: ['-'],
+      phone: '-',
+      createdBy: {
+        uid: decodedClaims.uid,
+        email: decodedClaims.email,
+        username: userData.username,
+      },
+      createdAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    })
+
+    return {
+      id: docRef.id,
+      message: '休み設定が作成されました',
+      startDate,
+      endDate,
+      createdBy: {
+        uid: decodedClaims.uid,
+        email: decodedClaims.email,
+        username: userData.username,
+      },
+    }
+  } catch (error: any) {
+    // 既に createError でスローされたエラーはそのまま再スロー
+    if (error.statusCode) {
+      throw error
+    }
+
+    console.error('休み設定作成エラー:', error)
+    throw createError({
+      statusCode: 500,
+      message: '休み設定の作成に失敗しました',
+    })
+  }
+})


### PR DESCRIPTION
休み日程を保存するデータベースをFirestoreに変更しました。


現段階では以下の状態です。
・休み日程の追加、編集、削除、既存の休み設定の取得ができるように変更しました。
・今まででに実装されていなかった、編集のときに重複チェックを導入しました。
・すでに予約が入っている日を休みにしようとすると休み設定ができない。（新規で休みを設定するとき & 既存の休みを編集するとき）
⇒例 : 12月10日～12月11日を休み設定。しかし12月10日にすでに予約が入っていた。12月10日～12月11日の期間は休みに設定できず、エラーメッセージを表示させる。

※このプルリクの目的は休み設定機能でのデータベースの移行になります。
（休み設定されているときに予約ができない機能は実装していません。このプルリクの目的と異なるため。）